### PR TITLE
Update Default Encoding to UTF8

### DIFF
--- a/Generate M3U8 From Json.ps1
+++ b/Generate M3U8 From Json.ps1
@@ -1,4 +1,6 @@
-﻿$channelsStarted = 0
+$PSDefaultParameterValues['Out-File:Encoding'] = 'utf8'
+
+$channelsStarted = 0
 $title = ""
 $logo = ""
 $headers = 0


### PR DESCRIPTION
I'm using https://ottplayer.tv/
When trying to use `https://rokuil.github.io/Live-From-Israel/Channels.m3u8` -- 
I'm getting this error:
<img width="388" alt="image" src="https://user-images.githubusercontent.com/3136012/170713602-775872bb-715e-4c87-819f-0ee3cb86abed.png">

So I've tried to follow this [StackOverflow Thread](https://stackoverflow.com/questions/40098771/changing-powershells-default-output-encoding-to-utf-8)  to fix it.

What do you think?

Current encoding is `UTF-16 LE`